### PR TITLE
docs: create security-committer-pathway.md

### DIFF
--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -2,13 +2,15 @@
 
 This guide, lays out a structured path for new members in Eclipse Tractus-X to contribute meaningfully and progress towards becoming committers. It emphasizes active participation, engagement in security-related tasks, and collaboration across different Special Interest Groups (SIGs) to build a comprehensive understanding and impact in the project's security landscape.
 
+## Community Integration
+
+- Become familiar with our [community](https://eclipse-tractusx.github.io/docs/developer)
+
+- Sign up for the [Eclipse Tractus-X mailing list](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute/#dev-mailinglist) to stay updated and share security updates.
+
 ## Participating in the DevSecOps Hour
 
 - Actively join the weekly DevSecOps Hour meetings every Friday to share security insights and answer developers' security queries.
-
-## Community Integration
-
-- Sign up for the [Eclipse Tractus-X mailing list](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute/#dev-mailinglist) to stay updated and share security updates.
 
 ## Active Contributions
 

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -14,7 +14,7 @@ This guide, lays out a structured path for new members in Eclipse Tractus-X to c
 
 ## Active Contributions
 
-- Answer security-related questions from developers that they bring to you via Teams Chat, email, or any other communication channel.
+- Answer security-related questions from developers that they bring to you via [Eclipse Matrix Space](https://matrix.to/#/#automotive.tractusx:matrix.eclipse.org), email, or any other communication channel.
 
 - Conduct security code reviews in Pull Requests (PRs), engaging in discussions to enhance security aspects.
 

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -8,7 +8,7 @@ This guide, lays out a structured path for new members in Eclipse Tractus-X to c
 
 ## Community Integration
 
-- Sign up for the Eclipse Tractus-X mailing list to stay updated and share security updates.
+- Sign up for the [Eclipse Tractus-X mailing list](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute/#dev-mailinglist) to stay updated and share security updates.
 
 ## Active Contributions
 

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -1,6 +1,6 @@
 # Pathway for New Members to Become _Security_ Committers in Eclipse Tractus-X
 
-This guide, lays out a structured path for new members in Eclipse Tractus-X to contribute meaningfully and progress towards becoming committers. It emphasizes active participation, engagement in security-related tasks, and collaboration across different Special Interest Groups (SIGs) to build a comprehensive understanding and impact in the project's security landscape.
+This guide, lays out a structured path for new members in Eclipse Tractus-X to contribute meaningfully and progress towards becoming [committers](https://www.eclipse.org/projects/handbook/#roles-cm). It emphasizes active participation, engagement in security-related tasks, and collaboration across different Special Interest Groups (SIGs) to build a comprehensive understanding and impact in the project's security landscape.
 
 ## Community Integration
 
@@ -37,7 +37,7 @@ This guide, lays out a structured path for new members in Eclipse Tractus-X to c
 
 # Additional Responsibilities for Established Security Committers
 
-Once you become a Security Committer in Eclipse Tractus-X, your role will expand to include the following critical responsibilities:
+Once you successfully [pass through the election process](https://www.eclipse.org/projects/handbook/#elections-committer) and are chosen by the existing committers, your role as a Security Committer in Eclipse Tractus-X will expand to include the following critical responsibilities:
 
 - Managing Security Advisories: Take charge of managing and responding to security advisories, ensuring timely and effective communication.
 

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -18,13 +18,13 @@ This guide, lays out a structured path for new members in Eclipse Tractus-X to c
 
 - Contribute to the development and integration of security tooling in the CI/CD process through PRs and participating in related discussions.
 
+## Engaging with Other SIGs
+
+- Regularly interact with SIGs for Infrastructure and Release to promote synergies and a holistic security perspective:
+
+  - [sig-infra](https://github.com/eclipse-tractusx/sig-infra)
+  - [sig-release](https://github.com/eclipse-tractusx/sig-release)
+ 
 ## Potential SIG-Security Meetings
 
 [Reserved for future dedicated SIG-Security meetings]
-
-## Engaging with Other SIGs
-
-- Regularly interact with SIGs for Infrastructure and Release to promote synergies and a holistic security perspective.
-
-
-

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -14,9 +14,9 @@ This guide, lays out a structured path for new members in Eclipse Tractus-X to c
 
 - Conduct security code reviews in Pull Requests (PRs), engaging in discussions to enhance security aspects.
 
-- Independently create PRs and issues for security assessments and threat modeling, actively contributing to their resolution.
+- Independently create PRs and issues for [security assessments](https://github.com/eclipse-tractusx/sig-security/blob/main/security-assessment.md) and threat modeling, actively contributing to their resolution.
 
-- Contribute to the development and integration of security tooling in the CI/CD process through PRs and participating in related discussions.
+- Contribute to the development and integration of [security tooling](https://github.com/eclipse-tractusx/sig-security/blob/main/security-tooling.md) in the CI/CD process through PRs and participating in related discussions.
 
 ## Engaging with Other SIGs
 

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -4,7 +4,7 @@ This guide, lays out a structured path for new members in Eclipse Tractus-X to c
 
 ## Community Integration
 
-- Become familiar with our [community](https://eclipse-tractusx.github.io/docs/developer)
+- Become familiar with our [community](https://eclipse-tractusx.github.io/docs/developer) and [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/).
 
 - Sign up for the [Eclipse Tractus-X mailing list](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute/#dev-mailinglist) to stay updated and share security updates.
 

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -26,7 +26,10 @@ This guide, lays out a structured path for new members in Eclipse Tractus-X to c
 
   - [sig-infra](https://github.com/eclipse-tractusx/sig-infra)
   - [sig-release](https://github.com/eclipse-tractusx/sig-release)
- 
+
+<!--
 ## Potential SIG-Security Meetings
 
 [Reserved for future dedicated SIG-Security meetings]
+-->
+

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -35,3 +35,12 @@ This guide, lays out a structured path for new members in Eclipse Tractus-X to c
 [Reserved for future dedicated SIG-Security meetings]
 -->
 
+# Additional Responsibilities for Established Security Committers
+
+Once you become a Security Committer in Eclipse Tractus-X, your role will expand to include the following critical responsibilities:
+
+- Managing Security Advisories: Take charge of managing and responding to security advisories, ensuring timely and effective communication.
+
+- Publishing CVEs: Oversee the process of publishing Common Vulnerabilities and Exposures (CVEs) related to the project, ensuring accurate and prompt disclosure.
+
+- Monitoring GitHub Advanced Security Dashboard: Keep a close eye on the security findings reported in the GitHub Advanced Security Dashboard, which involves analyzing and addressing the identified security issues in collaboration with the dev teams.

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -14,6 +14,8 @@ This guide, lays out a structured path for new members in Eclipse Tractus-X to c
 
 ## Active Contributions
 
+- Answer security-related questions from developers that they bring to you via Teams Chat, email, or any other communication channel.
+
 - Conduct security code reviews in Pull Requests (PRs), engaging in discussions to enhance security aspects.
 
 - Independently create PRs and issues for [security assessments](https://github.com/eclipse-tractusx/sig-security/blob/main/security-assessment.md) and threat modeling, actively contributing to their resolution.

--- a/security-committer-pathway.md
+++ b/security-committer-pathway.md
@@ -1,0 +1,30 @@
+# Pathway for New Members to Become _Security_ Committers in Eclipse Tractus-X
+
+This guide, lays out a structured path for new members in Eclipse Tractus-X to contribute meaningfully and progress towards becoming committers. It emphasizes active participation, engagement in security-related tasks, and collaboration across different Special Interest Groups (SIGs) to build a comprehensive understanding and impact in the project's security landscape.
+
+## Participating in the DevSecOps Hour
+
+- Actively join the weekly DevSecOps Hour meetings every Friday to share security insights and answer developers' security queries.
+
+## Community Integration
+
+- Sign up for the Eclipse Tractus-X mailing list to stay updated and share security updates.
+
+## Active Contributions
+
+- Conduct security code reviews in Pull Requests (PRs), engaging in discussions to enhance security aspects.
+
+- Independently create PRs and issues for security assessments and threat modeling, actively contributing to their resolution.
+
+- Contribute to the development and integration of security tooling in the CI/CD process through PRs and participating in related discussions.
+
+## Potential SIG-Security Meetings
+
+[Reserved for future dedicated SIG-Security meetings]
+
+## Engaging with Other SIGs
+
+- Regularly interact with SIGs for Infrastructure and Release to promote synergies and a holistic security perspective.
+
+
+


### PR DESCRIPTION
"The sig-security then would have a proper workflow + documentation on how to become active security expert (in a transparent way) and than people would/could nominate them to become committers from security and for security only."

